### PR TITLE
Add reference to the cmd utilities fitjson and fittxt to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,11 @@ Read a FIT file, frame by frame:
                 # are directly usable in your script logic.
                 print(frame.name)
 
+Command line utilities
+----------------------
+fitjson and fittxt export JSON and txt files::
+
+  $ fitjson in_file.fit -o out_file.json
 
 Installation
 ============


### PR DESCRIPTION
It is not obvious that the cmd utilities exist. I think they should be added the docs also.