### PR TITLE
Add error handling to _read_header

### DIFF
--- a/fitdecode/reader.py
+++ b/fitdecode/reader.py
@@ -347,7 +347,17 @@ class FitReader:
                 assert self._body_bytes_left == 0
 
                 self._reset_per_fit_state()
-                self._read_header()
+                
+                try:
+                    self._read_header()
+                except FitHeaderError as e:
+                    if self.error_handling is ErrorHandling.RAISE:
+                        raise
+                    elif self.error_handling is ErrorHandling.WARN:
+                        warnings.warn(str(e))
+                    # Skip the bad header and continue to the next one
+                    _update_state()
+                    continue
                 if self._header is None:
                     break
 


### PR DESCRIPTION
This is more of a sloppy workaround than a fix. Trying to get the parser to work on 3k files with intermittent bad headers without crashing. Attempts to address #30.

This code it will log a lot of warnings about `not a FIT file @ X` on files with bad headers and warn `file truncated? expected Y bytes, got Z @ W`.

I would love to find a great workaround but the [FIT protocol](https://developer.garmin.com/fit/protocol/) is pretty dense and I code much more than I read right now...