### PR TITLE
fix: replace deprecated argparse.FileType (Python 3.14+)

### DIFF
--- a/fitdecode/cmd/fitjson.py
+++ b/fitdecode/cmd/fitjson.py
@@ -5,6 +5,7 @@
 import argparse
 import datetime
 import json
+import os.path
 import re
 import sys
 import traceback
@@ -146,7 +147,7 @@ def parse_args(args=None):
         allow_abbrev=False)
 
     parser.add_argument(
-        '--output', '-o', type=argparse.FileType(mode='wt', encoding='utf-8'),
+        '--output', '-o',
         default='-',
         help='File to output data into (defaults to stdout)')
 
@@ -158,7 +159,7 @@ def parse_args(args=None):
         '--nocrc', action='store_const',
         const=fitdecode.CrcCheck.DISABLED,
         default=fitdecode.CrcCheck.WARN,
-        help='Some devices seem to write invalid CRC\'s, ignore these.')
+        help="Some devices seem to write invalid CRC's, ignore these.")
 
     parser.add_argument(
         '--nodef', action='store_true',
@@ -176,12 +177,25 @@ def parse_args(args=None):
             'messages; "+file_id" or "file_id" to include file_id messages.'))
 
     parser.add_argument(
-        'infile', metavar='FITFILE', type=argparse.FileType(mode='rb'),
+        'infile', metavar='FITFILE',
         help='Input .FIT file (use - for stdin)')
 
     options = parser.parse_args(args)
     options.filter, options.default_filter = \
         parse_filter_args(parser, options.filter)
+
+    # Resolve input file: '-' means stdin, otherwise a file path
+    if options.infile == '-':
+        options.infile = sys.stdin.buffer
+    else:
+        if not os.path.isfile(options.infile):
+            parser.error(f'file not found: "{options.infile}"')
+
+    # Resolve output file: '-' means stdout, otherwise open for writing
+    if options.output == '-':
+        options.output = sys.stdout
+    else:
+        options.output = open(options.output, mode='wt', encoding='utf-8')
 
     return options
 

--- a/fitdecode/cmd/fittxt.py
+++ b/fitdecode/cmd/fittxt.py
@@ -186,7 +186,7 @@ def global_stats(frames, options):
 
     stats = PrintableObject(
         _label='TXT',
-        name=os.path.basename(options.infile.name),
+        name=os.path.basename(options.infile_name),
         filter=filter_str,
         frames=len(frames),
         size=0,
@@ -328,7 +328,7 @@ def parse_args(args=None):
         allow_abbrev=False)
 
     parser.add_argument(
-        '--output', '-o', type=argparse.FileType(mode='wt', encoding='utf-8'),
+        '--output', '-o',
         default='-',
         help='File to output data into (defaults to stdout)')
 
@@ -336,7 +336,7 @@ def parse_args(args=None):
         '--nocrc', action='store_const',
         const=fitdecode.CrcCheck.DISABLED,
         default=fitdecode.CrcCheck.WARN,
-        help='Some devices seem to write invalid CRC\'s, ignore these')
+        help="Some devices seem to write invalid CRC's, ignore these")
 
     parser.add_argument(
         '--nodef', action='store_true',
@@ -358,12 +358,26 @@ def parse_args(args=None):
             'messages; "+file_id" or "file_id" to include file_id messages.'))
 
     parser.add_argument(
-        'infile', metavar='FITFILE', type=argparse.FileType(mode='rb'),
+        'infile', metavar='FITFILE',
         help='Input .FIT file (use - for stdin)')
 
     options = parser.parse_args(args)
     options.filter, options.default_filter = \
         parse_filter_args(parser, options.filter)
+
+    # Resolve input file: '-' means stdin, otherwise a file path
+    options.infile_name = options.infile
+    if options.infile == '-':
+        options.infile = sys.stdin.buffer
+    else:
+        if not os.path.isfile(options.infile):
+            parser.error(f'file not found: "{options.infile}"')
+
+    # Resolve output file: '-' means stdout, otherwise open for writing
+    if options.output == '-':
+        options.output = sys.stdout
+    else:
+        options.output = open(options.output, mode='wt', encoding='utf-8')
 
     return options
 
@@ -429,7 +443,7 @@ def main(args=None):
         txt_print(global_stats(frames, options))
         echo('')
     else:
-        echo('ERROR OCCURRED WHILE PARSING', options.infile.name)
+        echo('ERROR OCCURRED WHILE PARSING', options.infile_name)
         echo('')
         echo(exception_msg)
         echo('')


### PR DESCRIPTION
## Summary

Replace deprecated `argparse.FileType` usage in `fittxt.py` and `fitjson.py` with manual file path arguments and explicit `open()` calls after `parse_args()`.

**Motivation:** Python 3.14 deprecates `argparse.FileType` ([cpython#82620](https://github.com/python/cpython/issues/82620)). This causes `DeprecationWarning` on 3.14+ and will eventually break.

## Changes

- **`fitdecode/cmd/fittxt.py`**: Replace `type=argparse.FileType(mode=...)` on both `--output` and `infile` arguments with plain string arguments. After `parse_args()`, resolve `-` to stdin/stdout and open file paths manually. Added `options.infile_name` for display in `global_stats()`.
- **`fitdecode/cmd/fitjson.py`**: Same pattern -- replace `argparse.FileType` with string arguments and manual file handling.

## Behavior preserved

- `-` still works for stdin (input) and stdout (output)
- `FitReader` accepts both file paths (str) and file-like objects, so passing the path string directly works without opening the file beforehand
- Error messages for missing input files are now shown before any processing starts (early validation)

Fixes #35
